### PR TITLE
fix(db): resolve DB URL without ConfigParser interpolation

### DIFF
--- a/.llm-wiki/wiki/sources/obs-2026-07-22-db-password-masked-in-env-py-database-py-logs-via-render-as-.md
+++ b/.llm-wiki/wiki/sources/obs-2026-07-22-db-password-masked-in-env-py-database-py-logs-via-render-as-.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: DB password masked in env.py/database.py logs via render_as_string(hide_password=True)"
+slug: obs-2026-07-22-db-password-masked-in-env-py-database-py-logs-via-render-as-
+status: observation
+created: 2026-07-22
+updated: 2026-07-22
+relevance: high
+observed_at: 2026-07-22T17:34:35.200Z
+tags: ["security", "logging", "database", "url-masking", "alembic"]
+source_context: "Follow-up to issue #18 fix: masking DB password in env.py/database.py logs"
+---
+# ⭐ Observation: DB password masked in env.py/database.py logs via render_as_string(hide_password=True)
+Fixed a cleartext password leak in cape-cod-db logging. cape_cod_db/migrations/env.py and cape_cod_db/database.py both logged the DB URL with f"Configured for database: {db_url}" where db_url is a plain string, exposing the (percent-encoded) password in logs -- a violation of the AGENTS.md "never log credentials" rule. Fix: log make_url(db_url).render_as_string(hide_password=True), which renders the password as ***, while the raw db_url string is still used unchanged for create_engine. Added `from sqlalchemy.engine import make_url` to both files. Note: SQLAlchemy's URL object masks the password on str()/repr() by default; the leak existed only because the code logged the raw string, not a URL object. Verified at runtime: log shows postgresql://user:***@host/db and the engine still receives the raw URL. Pre-existing issue, surfaced while cleaning up the issue #18 fix.
+*Relevance: high*
+
+*Context: Follow-up to issue #18 fix: masking DB password in env.py/database.py logs*
+
+*Tags: security logging database url-masking alembic*
+---
+*Observed: 2026-07-22T17:34:35.200Z*

--- a/.llm-wiki/wiki/sources/obs-2026-07-22-env-py-db-url-resolution-decoupled-from-configparser-interpo.md
+++ b/.llm-wiki/wiki/sources/obs-2026-07-22-env-py-db-url-resolution-decoupled-from-configparser-interpo.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: env.py DB URL resolution decoupled from ConfigParser interpolation"
+slug: obs-2026-07-22-env-py-db-url-resolution-decoupled-from-configparser-interpo
+status: observation
+created: 2026-07-22
+updated: 2026-07-22
+relevance: high
+observed_at: 2026-07-22T17:24:16.863Z
+tags: ["alembic", "database", "migrations", "bugfix", "url-encoding"]
+source_context: "Fixing GitHub issue #18 (env.py ConfigParser interpolation on % in DB URLs)"
+---
+# ⭐ Observation: env.py DB URL resolution decoupled from ConfigParser interpolation
+Fixed issue #18 in cape-cod-db. cape_cod_db/migrations/env.py used to store the DB URL via config.set_main_option and re-read it through Alembic's ConfigParser (BasicInterpolation), so any '%' in a percent-encoded password raised configparser.InterpolationSyntaxError. Fix: added a pure resolve_db_url(cli_args, environ, ini_url) helper (precedence: CLI -x db_url -> DB_URL env -> ini sqlalchemy.url, SystemExit if None), removed set_main_option, and now pass the resolved db_url straight to context.configure(url=db_url) offline and create_engine(db_url, poolclass=pool.NullPool) online (imported create_engine from sqlmodel, dropped engine_from_config). cape_cod_db/database.py now does `from .migrations.env import db_url` instead of config.get_main_option; its existing `except AttributeError` DB_URL fallback still works because importing env.py outside Alembic raises AttributeError at `config = context.config`. Confirmed BasicInterpolation only treats '%' as special -- '$' passes through fine, so it was never part of this bug. Added tests/test_db_url.py (pytest) covering % @ : / space # ? plus a combined password, asserting make_url(url).password == raw. Verified: ruff clean, pyright 0 errors, pytest passes.
+*Relevance: high*
+
+*Context: Fixing GitHub issue #18 (env.py ConfigParser interpolation on % in DB URLs)*
+
+*Tags: alembic database migrations bugfix url-encoding*
+---
+*Observed: 2026-07-22T17:24:16.863Z*

--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ ever.
 This script requires the `DB_URL` environment variable be set and does not work
 with alembic at all, so the alembic config is not needed.
 
+### Running Tests
+
+Unit tests live in `tests/` and run with `pytest` (installed via
+`poetry install`). They are plain unit tests and do not require a running
+database.
+
+```bash
+# run the full suite
+poetry run pytest
+
+# run a single file or test, verbosely
+poetry run pytest tests/test_db_url.py -v
+```
+
 ### Test Data
 
 Test data fixtures are provided in `fixtures/test/`:

--- a/cape_cod_db/database.py
+++ b/cape_cod_db/database.py
@@ -1,11 +1,12 @@
 import logging
 
+from sqlalchemy.engine import make_url
 from sqlmodel import SQLModel, create_engine
 
 db_url = None
 
 try:
-    from .migrations.env import config
+    from .migrations.env import db_url
 
     logger = logging.getLogger("alembic.env")
 
@@ -13,7 +14,6 @@ try:
     # doing orm things (e.g. in an api lambda) we need another source to check
     # some other source for the DB  URL as the config object doesn't exit in
     # env.py. alembic doesn't play when we're just doing orm things.
-    db_url = config.get_main_option("sqlalchemy.url")
 except AttributeError:
     logging.basicConfig()
     logger = logging.getLogger(__file__)
@@ -33,7 +33,9 @@ if db_url is None:
     )
     exit(1)
 
-logger.info(f"Configured for database: {db_url}")
+logger.info(
+    f"Configured for database: {make_url(db_url).render_as_string(hide_password=True)}"
+)
 
 engine = create_engine(db_url)
 

--- a/cape_cod_db/db_url.py
+++ b/cape_cod_db/db_url.py
@@ -1,0 +1,17 @@
+"""Side-effect-free helper for resolving the database URL.
+
+Kept separate from ``migrations/env.py`` so the resolution logic can be
+imported (and unit tested) without triggering Alembic's import-time
+migration side effects.
+"""
+
+
+def resolve_db_url(cli_args, environ, ini_url):
+    """Resolve the DB URL by precedence: CLI -x db_url, then DB_URL env,
+    then the alembic ini sqlalchemy.url. Returns the URL string."""
+    db_url = cli_args.get("db_url") or environ.get("DB_URL") or ini_url
+    if db_url is None:
+        raise SystemExit(
+            "DB_URL is not configured (CLI -x db_url, env DB_URL, or ini sqlalchemy.url)"
+        )
+    return db_url

--- a/cape_cod_db/migrations/env.py
+++ b/cape_cod_db/migrations/env.py
@@ -3,8 +3,11 @@ import os
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
-from sqlmodel import SQLModel
+from sqlalchemy import pool
+from sqlalchemy.engine import make_url
+from sqlmodel import SQLModel, create_engine
+
+from cape_cod_db.db_url import resolve_db_url
 
 # NOTE: as new table models are added, they need to be imported here.
 # These imports register the models on SQLModel.metadata so Alembic
@@ -43,21 +46,12 @@ target_metadata = SQLModel.metadata
 # - alembic config file value `sqlalchemy.url`
 
 cli_args = context.get_x_argument(as_dictionary=True)
-
-# first try a cli arg
-db_url = cli_args.get("db_url", None)
-
-# then an env var
-if db_url is None:
-    db_url = os.getenv("DB_URL")
-
-# we've already got the file config, so if db_url is not None by here, overwrite
-# the file config value
-if db_url is not None:
-    config.set_main_option("sqlalchemy.url", db_url)
+db_url = resolve_db_url(
+    cli_args, os.environ, config.get_main_option("sqlalchemy.url")
+)
 
 logging.info(
-    f"Configured for database: {config.get_main_option('sqlalchemy.url')}"
+    f"Configured for database: {make_url(db_url).render_as_string(hide_password=True)}"
 )
 
 # other values from the config, defined by the needs of env.py,
@@ -96,9 +90,8 @@ def run_migrations_offline() -> None:
         "pk": "pk_%(table_name)s",
     }
 
-    url = config.get_main_option("sqlalchemy.url")
     context.configure(
-        url=url,
+        url=db_url,
         target_metadata=target_metadata,
         # look for column type changes
         compare_type=True,
@@ -123,11 +116,7 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    connectable = create_engine(db_url, poolclass=pool.NullPool)
 
     # since different DB vendors use different default naming conventions for
     # things, and sqlalchemy can have issue with these sometimes, we're using

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,11 +108,30 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\""
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
+    {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "greenlet"
@@ -181,6 +200,18 @@ files = [
 [package.extras]
 docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil", "setuptools"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
 
 [[package]]
 name = "isort"
@@ -380,6 +411,22 @@ files = [
     {file = "platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"},
     {file = "platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"},
 ]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "psycopg2-binary"
@@ -615,6 +662,21 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyright"
 version = "1.1.411"
 description = "Command line wrapper for pyright"
@@ -634,6 +696,30 @@ typing-extensions = ">=4.1"
 all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
 nodejs = ["nodejs-wheel-binaries"]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytokens"
@@ -924,4 +1010,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e5385549bcebadbd7ce6f2ec527e3f21329cfaa40afaeb7f0aa22d7b33402f7a"
+content-hash = "84bc5188af322b776bd73fe2ca56c0b8db454db8a28fa8a02d70b57e5d3b232f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,9 @@ extend-exclude = ["cape_cod_db/migrations"]
 
 [dependency-groups]
 dev = [
-    "ruff (>=0.15.19,<0.16.0)",
-    "pyright (>=1.1.411,<2.0.0)",
-    "black (>=26.5.1,<27.0.0)",
-    "isort (>=8.0.1,<9.0.0)"
+  "ruff (>=0.15.19,<0.16.0)",
+  "pyright (>=1.1.411,<2.0.0)",
+  "black (>=26.5.1,<27.0.0)",
+  "isort (>=8.0.1,<9.0.0)",
+  "pytest (>=8.0.0,<9.0.0)",
 ]

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -1,0 +1,25 @@
+from urllib.parse import quote
+
+from sqlalchemy.engine import make_url
+
+from cape_cod_db.db_url import resolve_db_url
+
+
+def test_resolve_db_url_accepts_percent_encoded_passwords():
+    raw_passwords = [
+        "pa%ss1",
+        "pa@ss1",
+        "pa:ss1",
+        "pa/ss1",
+        "pa ss1",
+        "pa#ss1",
+        "pa?ss1",
+        "p%ss@w:o/rd #?x",
+    ]
+
+    for raw_password in raw_passwords:
+        encoded_password = quote(raw_password, safe="")
+        url = f"postgresql://user:{encoded_password}@host:5432/db"
+
+        assert resolve_db_url({}, {}, url) == url, raw_password
+        assert make_url(url).password == raw_password, raw_password


### PR DESCRIPTION
## Summary

Fixes #18. `env.py` routed the DB URL through Alembic's `Config`, backed by a `ConfigParser` using `BasicInterpolation`, so any `%` in a percent-encoded password raised `InterpolationSyntaxError` before a connection was attempted. Percent-encoding is unavoidable for passwords containing `@ : / <space>` etc., and a literal `%` (e.g. an AWS-rotated RDS password) encodes to `%25`, so this broke a whole class of valid passwords.

**env.py / db_url.py**
- Resolve the URL via a new side-effect-free `resolve_db_url` helper in `cape_cod_db/db_url.py`; stop calling `set_main_option` and re-reading through the interpolating parser.
- Online migrations build the engine with `create_engine(db_url, ...)`; offline passes `url=db_url` directly to `context.configure`.

**database.py**
- Import the resolved `db_url` from `env.py` instead of `config.get_main_option`; the existing `DB_URL` env fallback still works.

**security**
- Mask the password in configuration logs via `make_url(db_url).render_as_string(hide_password=True)` in both `env.py` and `database.py`.

**tests / docs**
- Add `pytest` and a regression test covering percent-encoded passwords (`% @ : / <space> # ?` plus a combined case), asserting `make_url(url).password` round-trips.
- Add a "Running Tests" section to the README.

## Verification

`poetry run ruff check`, `poetry run pyright`, and `poetry run pytest` all pass. Confirmed `make_url("postgresql://user:p%25ss%40word@host/db").password == "p%ss@word"` and that the config log renders `user:***`.

## Related

Once released, `cape-ph/cape-cod-env` can drop its `%%` workaround in `roles/common/tasks/resolve_db_url.yaml` and pass the plain percent-encoded URL.